### PR TITLE
Criação do keypair com a key da maquina linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,41 @@
 
 ## Como usar.
   - Para utilizar localmente , baixe o repositório e altere as variáveis localizadas no arquivo `terraform.tfvars` de acordo com a necessidade.
-  - A variável `count_available` define o quantidade de zonas de disponibilidade, públicas e privadas que seram criadas, a variável `key` especifíca o nome 
-  da **key pair** existente na AWS, certifique-se que ja possua uma ou então à crie e utilize na variável.      
+  - A variável `count_available` define o quantidade de zonas de disponibilidade, públicas e privadas que seram criadas.
+  - A variável `key` especifica o nome da **key pair** existente na AWS, certifique-se que ja possua uma ou então à crie e utilize na variável.   
+      - Caso esteja usando o Linux e queira usar como **key pair** sua chave publica, especifique o *path* da sua chave publica em uma  variável em [variables.tf](worknodes/variables.tf) e crie esta key atraves do recurso *aws_key_pair* em  [nodes.tf](worknodes/nodes.tf). ex:  
+
+      ```tf
+          variable "key_path" {
+            description = "Public key path"
+            default     = "/home/usuario/.ssh/id_rsa.pub"
+          }
+      ```  
+    [worknodes/variables.tf](worknodes/variables.tf)   
+
+      ```tf
+          resource "aws_key_pair" "myawskeypair" {  
+              key_name   = "myawskeypair"
+              public_key = file("${var.key_path}")
+          }
+      ```  
+    [worknodes/nodes.tf](worknodes/nodes.tf)
+
+    
+      ```tf
+        ...
+
+        remote_access {
+          ec2_ssh_key               = aws_key_pair.myawskeypair.key_name
+          source_security_group_ids = [var.security_group_id]
+        }
+        ...
+
+      ```  
+    [worknodes/nodes.tf](worknodes/nodes.tf)
+
+    
+
   - Este projeto possue um módulo de security group adicional, as regras de ingress listadas ali são somente exemplos, então gerencie conforme necessitar 
   editando seus valores no arquivo `terraform.tfvars`.      
   - Certifique-se que possua as credenciais da AWS - **`AWS_ACCESS_KEY_ID`** e **`AWS_SECRET_ACCESS_KEY`**.
@@ -110,14 +143,12 @@ Agora é só executar os comandos do terraform:
 * `terraform apply` - Para aplicar a criação/alteração dos recursos. 
 
 ### Aguarde a criação do cluster EKS, após concluir execute os comandos abaixo:
-* Conectar ao cluster.            
-  `$ aws eks --region $(terraform output -raw region) update-kubeconfig --name $(terraform output -raw cluster_name)`
+* Conecte o cluster com o comando abaixo completo ou preencha com o nome do cluster, a região e execute o comando.  
+
+  `aws eks --region $(terraform output -raw region) update-kubeconfig --name $(terraform output -raw cluster_name)`
 
 * Pegar o kubeconfig.            
   `aws sts get-caller-identity`
-
-* Preencha o espaço abaixo com o nome do cluster e execute o comando.            
-  `aws eks --region us-east-1 update-kubeconfig --name <NOME_CLUSTER>`
 
 * Verificar o kubeconfig.            
   `cat ~/.kube/config`

--- a/worknodes/nodes.tf
+++ b/worknodes/nodes.tf
@@ -15,7 +15,7 @@ resource "aws_eks_node_group" "nodegroup" {
     max_unavailable = 2
   }
   remote_access {
-    ec2_ssh_key               = var.key
+    ec2_ssh_key               = aws_key_pair.myawskeypair.key_name
     source_security_group_ids = [var.security_group_id]
   }
 
@@ -29,4 +29,10 @@ resource "aws_eks_node_group" "nodegroup" {
   tags = {
     Name = var.tagworknodes
   }
+}
+
+
+resource "aws_key_pair" "myawskeypair" {  
+    key_name   = "myawskeypair"
+    public_key = file("${var.key_path}")
 }

--- a/worknodes/variables.tf
+++ b/worknodes/variables.tf
@@ -36,3 +36,9 @@ variable "key" {
   description = "Nome da key pair"
   type        = string
 }
+
+variable "key_path" {
+  description = "Public key path"
+  default     = "/home/usuario/.ssh/id_rsa.pub"
+}
+


### PR DESCRIPTION
na criação do cluster precisa de um keypair. Foi desenvolcido um modo para esta key ser cirad dinamicamente com a chave publica do Linux. Lembrando que este modo é para quem está usando para fins de estudos, pois esta chave Key esta na maquina que está subindo o Terraform.

        modified:   README.md
        modified:   worknodes/nodes.tf
        modified:   worknodes/variables.tf